### PR TITLE
Added support for comment delimiter in values

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/source/Innovatian.Configuration.Tests/IniConfigurationSourceTests.cs
+++ b/source/Innovatian.Configuration.Tests/IniConfigurationSourceTests.cs
@@ -51,6 +51,45 @@ namespace Innovatian.Configuration.Tests
         }
 
         [Fact]
+        public void CanProcessValidIniFileWithSingleLineComments()
+        {
+            var source = new IniConfigurationSource(Resources.IniTestCases, true);
+            List<IConfigurationSection> sections = source.Sections.Values.ToList();
+
+            Assert.Equal(5, sections.Count);
+            Assert.Equal("owner", sections[0].Name);
+            Assert.Equal(2, sections[0].Count);
+            Assert.Equal(sections[0].Get<string>("name"), "John Doe");
+            Assert.Equal(sections[0].Get<string>("organization"), "Acme Products");
+
+            Assert.Equal("database", sections[1].Name);
+            Assert.Equal(3, sections[1].Count);
+            Assert.Equal(sections[1].Get<string>("server"), "192.0.2.42     ; use IP address in case network name resolution is not working");
+            Assert.Equal(sections[1].Get<string>("port"), "143");
+            Assert.Equal(sections[1].Get<string>("file"), "\"acme payroll.dat\"");
+
+            Assert.Equal("Empty", sections[2].Name);
+            Assert.Equal(1, sections[2].Count);
+            Assert.Equal(sections[2].Get<string>("MyEmptyValue"), "");
+
+            Assert.Equal("Completely Empty Section", sections[3].Name);
+            Assert.Equal(0, sections[3].Count);
+
+            Assert.Equal("NonEmptyAfterCompletelyEmpty", sections[4].Name);
+            Assert.Equal(1, sections[4].Count);
+            Assert.Equal(sections[4].Get<string>("mykey"), "myval  akdk     ;");
+
+            foreach (IConfigurationSection section in source.Sections.Values)
+            {
+                foreach (KeyValuePair<string, string> pair in section)
+                {
+                    Console.WriteLine(pair.Key + ", " + pair.Value);
+                }
+            }
+        }
+
+
+        [Fact]
         public void CanGetValueContainingEqualSign()
         {
             var source = new IniConfigurationSource(Resources.IniTestCaseMultipleEqualSigns);


### PR DESCRIPTION
I have added support for having the comment character as part of values. Also enabled custom delimiting and comment strings, and support for normalised line endings.
